### PR TITLE
Feature/refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+.DS_Store

--- a/format/formatters.go
+++ b/format/formatters.go
@@ -1,8 +1,10 @@
-package response
+package format
 
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/LUSHDigital/microservice-core-golang/response"
 )
 
 // JSONResponseFormatter - Format a microservice response as JSON.
@@ -10,7 +12,7 @@ import (
 // Params:
 //     w http.ResponseWriter - The HTTP response writer.
 //     response *Response - The microservice response object.
-func JSONResponseFormatter(w http.ResponseWriter, response *Response) {
+func JSONResponseFormatter(w http.ResponseWriter, response *response.Response) {
 	// Set the content type header.
 	w.Header().Set("Content-Type", "application/json")
 

--- a/format/formatters.go
+++ b/format/formatters.go
@@ -9,8 +9,8 @@ import (
 //
 // Params:
 //     w http.ResponseWriter - The HTTP response writer.
-//     response *MicroserviceResponse - The microservice response object.
-func JSONResponseFormatter(w http.ResponseWriter, response *MicroserviceResponse) {
+//     response *Response - The microservice response object.
+func JSONResponseFormatter(w http.ResponseWriter, response *Response) {
 	// Set the content type header.
 	w.Header().Set("Content-Type", "application/json")
 

--- a/format/formatters_test.go
+++ b/format/formatters_test.go
@@ -1,4 +1,4 @@
-package response
+package format
 
 import (
 	"encoding/json"
@@ -9,9 +9,11 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+
+	"github.com/LUSHDigital/microservice-core-golang/response"
 )
 
-var responseData = Data{
+var responseData = response.Data{
 	Type: "tests",
 	Content: map[string]interface{}{
 		"tests":    "ok",
@@ -27,9 +29,9 @@ func TestJSONResponseFormatter(t *testing.T) {
 	// Start a HTTP server for testing purposes.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Create a response.
-		response := New(200, StatusOk, "", &responseData)
+		resp := response.New(200, response.StatusOk, "", &responseData)
 		// Format the response as JSON.
-		JSONResponseFormatter(w, response)
+		JSONResponseFormatter(w, resp)
 	}))
 	defer ts.Close()
 

--- a/format/formatters_test.go
+++ b/format/formatters_test.go
@@ -11,10 +11,12 @@ import (
 	"testing"
 )
 
-// Response data for testing with.
-var responseData = map[string]interface{}{
-	"tests":    "ok",
-	"language": "golang",
+var responseData = Data{
+	Type: "tests",
+	Content: map[string]interface{}{
+		"tests":    "ok",
+		"language": "golang",
+	},
 }
 
 // The expected response body.
@@ -25,8 +27,7 @@ func TestJSONResponseFormatter(t *testing.T) {
 	// Start a HTTP server for testing purposes.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Create a response.
-		response := CreateResponse("tests", responseData, 200, StatusOk, "")
-
+		response := New(200, StatusOk, "", &responseData)
 		// Format the response as JSON.
 		JSONResponseFormatter(w, response)
 	}))

--- a/response/response.go
+++ b/response/response.go
@@ -39,10 +39,6 @@ func (d *Data) Valid() bool {
 // MarshalJSON implements the Marshaler interface and is there to ensure the output
 // is correct when we return data to the consumer
 func (d *Data) MarshalJSON() ([]byte, error) {
-	if !d.Valid() {
-		return []byte{}, fmt.Errorf("data provided, type cannot be empty")
-	}
-
 	return json.Marshal(d.Map())
 }
 

--- a/response/response.go
+++ b/response/response.go
@@ -2,8 +2,8 @@ package response
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
-	"regexp"
 	"strings"
 )
 
@@ -13,65 +13,77 @@ const (
 	StatusFail = "fail"
 )
 
-// MicroserviceResponse - A standardised response format for a microservice.
-type MicroserviceResponse struct {
-	Status  string                 `json:"status"`
-	Code    int                    `json:"code"`
-	Message string                 `json:"message"`
-	Data    map[string]interface{} `json:"data,omitempty"`
+// Response - A standardised response format for a microservice.
+type Response struct {
+	Status  string `json:"status"`
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+	Data    *Data  `json:"data,omitempty"`
 }
 
-// CreateResponse - Prepare a response for a microservice endpoint.
-//
+// Data represents the collection data the the response will return to the consumer
+// Type ends up being the name of the key containing the collection of Content
+type Data struct {
+	Type    string
+	Content map[string]interface{}
+}
+
+// Valid ensures the Data passed to the response is correct
+func (d *Data) Valid() bool {
+	if d.Type != "" {
+		return true
+	}
+	return false
+}
+
+// MarshalJSON implements the Marshaler interface and is there to ensure the output
+// is correct when we return data to the consumer
+func (d *Data) MarshalJSON() ([]byte, error) {
+	if !d.Valid() {
+		return []byte{}, fmt.Errorf("data provided, type cannot be empty")
+	}
+
+	return json.Marshal(d.Map())
+}
+
+// Map returns a version of the data as a map
+func (d *Data) Map() map[string]interface{} {
+	d.Type = strings.Replace(strings.ToLower(d.Type), " ", "-", -1)
+	if !d.Valid() {
+		log.Printf("invalid data: %v", d)
+		return nil
+	}
+
+	return map[string]interface{}{
+		d.Type: d.Content,
+	}
+}
+
+// New returns a new Response for a microservice endpoint
 // This ensures that all API endpoints return data in a standardised format:
 //
-// {
-//     "status": "ok", - Can contain any string. Usually 'ok', 'error' etc.
-//     "code": 200, - A HTTP status code.
-//     "message": "", - A message string elaborating on the status.
-//     "data": {[ - A collection of return data. Can be omitted in the event
-//     ]}           an error occurred.
-// }
-//
+//    {
+//       "status": "ok", - Can contain any string. Usually 'ok', 'error' etc.
+//       "code": 200, - A HTTP status code.
+//       "message": "", - A message string elaborating on the status.
+//       "data": {[ - A collection of return data. Can be omitted in the event an error occurred.
+//       ]}
+//    }
 // Params:
-//     Type string - The type of data being returned. Will be used to name the
-//     collection.
-//     Data interface{} - The data to return. Will always be parsed into a
-//     collection.
-//     Code int - HTTP status code for the response.
-//     Status - A short status message. Examples: 'OK', 'Bad Request',
-//     'Not Found'.
-//     Message string - A more detailed status message.
+//   - [code] - HTTP status code for the response.
+//   - [status] - A short status message. Examples: 'OK', 'Bad Request', 'Not Found' etc...
+//   - [message] - A more detailed status message
+//   - [data] The data to return. Will always be parsed into a collection.
 //
 // Return:
-//     *MicroserviceResponse - The populated response object.
-func CreateResponse(Type string, Data interface{}, Code int, Status string, Message string) *MicroserviceResponse {
-	// Validate the arguments.
-	if Data != nil && Type == "" {
-		log.Fatal("Cannot prepare response. No type specified.")
-	} else {
-		reg, err := regexp.Compile("[^A-Za-z]")
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		Type = reg.ReplaceAllString(strings.ToLower(Type), "-")
+//   *Response - The populated response object.
+func New(code int, status, message string, data *Data) *Response {
+	return &Response{
+		Code:    code,
+		Status:  status,
+		Message: message,
+		Data:    data,
 	}
-
-	// Prepare the response object.
-	response := &MicroserviceResponse{
-		Status:  Status,
-		Code:    Code,
-		Message: Message,
-	}
-
-	// Only add the data if supplied.
-	if Data != nil {
-		response.Data = make(map[string]interface{})
-		response.Data[Type] = Data
-	}
-
-	return response
 }
 
 // ExtractData - Extract a particular item of data from the response.
@@ -82,8 +94,12 @@ func CreateResponse(Type string, Data interface{}, Code int, Status string, Mess
 //
 // Return:
 //     error - An error if it occurred.
-func (response MicroserviceResponse) ExtractData(srcKey string, dst interface{}) error {
-	for key, value := range response.Data {
+func (r *Response) ExtractData(srcKey string, dst interface{}) error {
+	if !r.Data.Valid() {
+		return fmt.Errorf("invalid data provided: %v", r.Data)
+	}
+
+	for key, value := range r.Data.Map() {
 		if key != srcKey {
 			continue
 		}

--- a/response/response_test.go
+++ b/response/response_test.go
@@ -1,86 +1,266 @@
 package response
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
+
+	"fmt"
+
+	"log"
 )
 
+func init() {
+	log.SetFlags(log.Lshortfile | log.LstdFlags)
+}
+
 // An example data type.
-var expectedResponseDataType = "tests"
+var (
+	// An example data set for testing with.
+	expectedResponseData = map[string]interface{}{
+		"tests":    "ok",
+		"language": "golang",
+	}
+	// example Data struct
+	preparedData = &Data{
+		Type:    "tests",
+		Content: expectedResponseData,
+	}
 
-// An example data set for testing with.
-var expectedResponseData = map[string]interface{}{
-	"tests":    "ok",
-	"language": "golang",
-}
+	// An example response object for testing with.
+	expectedResponse = &Response{
+		Status:  StatusOk,
+		Code:    200,
+		Message: "",
+		Data: &Data{
+			Type:    "tests",
+			Content: expectedResponseData,
+		},
+	}
 
-// An example response object for testing with.
-var expectedResponse = &MicroserviceResponse{
-	Status:  StatusOk,
-	Code:    200,
-	Message: "",
-	Data: map[string]interface{}{
-		"tests": expectedResponseData,
-	},
-}
+	// An example response object (with no data) for testing with.
+	expectedResponseNoData = &Response{
+		Status:  StatusOk,
+		Code:    200,
+		Message: "",
+	}
 
-// An example response object (with no data) for testing with.
-var expectedResponseNoData = &MicroserviceResponse{
-	Status:  StatusOk,
-	Code:    200,
-	Message: "",
-}
+	// the expected error in case type is missing
+	errorTypeEmptyWhenDataProvided = "data provided, type cannot be empty"
+)
 
-// TestResponseObject - Check the response creator is providing a valid
-// response.
-func TestResponseObject(t *testing.T) {
-	// Create a response.
-	response := CreateResponse(expectedResponseDataType, expectedResponseData, 200, StatusOk, "")
+func TestNew(t *testing.T) {
+	tt := []struct {
+		name     string
+		code     int
+		status   string
+		message  string
+		typ      string
+		data     *Data
+		expected *Response
+	}{
+		{
+			name:     "response valid",
+			code:     200,
+			status:   StatusOk,
+			message:  "",
+			data:     preparedData,
+			expected: expectedResponse,
+		},
+		{
+			name:     "response no data",
+			code:     200,
+			status:   StatusOk,
+			message:  "",
+			data:     nil,
+			expected: expectedResponseNoData,
+		},
+	}
 
-	// Check the response.
-	if !reflect.DeepEqual(response, expectedResponse) {
-		t.Error(fmt.Sprintf("Expected %v, got %v", response, expectedResponse))
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := New(tc.code, tc.status, tc.message, tc.data)
+
+			if !reflect.DeepEqual(resp, tc.expected) {
+				t.Errorf("want: %v\ngot: %v", tc.expected, resp)
+			}
+		})
 	}
 }
 
-// TestResponseObjectNoData - Check the response creator is providing a valid
-// response if there is no data.
-func TestResponseObjectNoData(t *testing.T) {
-	// Create a response.
-	response := CreateResponse(expectedResponseDataType, nil, 200, StatusOk, "")
-
-	// Check the response.
-	if !reflect.DeepEqual(response, expectedResponseNoData) {
-		t.Error(fmt.Sprintf("Expected %v, got %v", response, expectedResponseNoData))
-	}
-}
-
-// TestExtractData - Check the ExtractData function.
-func TestExtractData(t *testing.T) {
-	// Create a response.
-	response := CreateResponse(expectedResponseDataType, expectedResponseData, 200, StatusOk, "")
-
+func TestResponse_ExtractData(t *testing.T) {
+	resp := New(200, StatusOk, "", preparedData)
+	//
 	// Extract the data.
 	var dst map[string]interface{}
-	extractedData := response.ExtractData("tests", dst)
-
+	extractedData := resp.ExtractData("tests", dst)
+	//
 	// Compare the data.
-	if reflect.DeepEqual(dst, response.Data["tests"]) {
-		t.Errorf("TestExtractData: Expected %v got %v", response.Data["tests"], extractedData)
+	if reflect.DeepEqual(dst, resp.Data.Map()["test"]) {
+		t.Errorf("TestExtractData: Expected %v got %v", resp.Data.Map()["tests"], extractedData)
+	}
+
+	// test with broken data as well
+	resp = New(200, StatusOk, "", &Data{
+		Content: expectedResponseData,
+	})
+	//
+	// Extract the data.
+	dst = nil
+	extractedData = resp.ExtractData("tests", dst)
+	//
+	// Compare the data.
+	if reflect.DeepEqual(dst, nil) {
+		t.Errorf("TestExtractData: Expected %v got %v", resp.Data.Map()["tests"], extractedData)
 	}
 }
 
-// ExampleCreateResponse - Example usage for the CreateResponse function.
-func ExampleCreateResponse() {
-	someThings := map[string]string{
-		"thing_one": "a thing",
-		"thing_two": "another thing",
+func TestData_MarshalJSON(t *testing.T) {
+	tt := []struct {
+		name string
+		data Data
+	}{
+		{
+			name: "correct data",
+			data: Data{
+				Type:    "testCollection",
+				Content: map[string]interface{}{"test": "test"},
+			},
+		},
+		{
+			name: "missing data",
+			data: Data{
+				Type:    "testCollection",
+				Content: map[string]interface{}{},
+			},
+		},
+		{
+			name: "missing type",
+			data: Data{
+				Type:    "",
+				Content: map[string]interface{}{"test": "test"},
+			},
+		},
+		{
+			name: "missing all data",
+			data: Data{
+				Type:    "",
+				Content: nil,
+			},
+		},
 	}
 
-	response := CreateResponse("things", someThings, 200, StatusOk, "")
-	fmt.Printf("%+v", response)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.data.MarshalJSON()
+			if err != nil && err.Error() != errorTypeEmptyWhenDataProvided {
+				t.Errorf("test '%v' failed with error: %v", tc.name, err)
+			}
+		})
+	}
+}
 
-	// Output:
-	// &{Status:ok Code:200 Message: Data:map[things:map[thing_one:a thing thing_two:another thing]]}
+func TestData_Map(t *testing.T) {
+	tt := []struct {
+		name     string
+		data     Data
+		expected map[string]interface{}
+	}{
+		{
+			name: "map valid data",
+			data: Data{
+				Type: "things",
+				Content: map[string]interface{}{
+					"thing_one": "a thing",
+					"thing_two": "another thing",
+				},
+			},
+			expected: map[string]interface{}{
+				"things": map[string]interface{}{
+					"thing_one": "a thing",
+					"thing_two": "another thing",
+				},
+			},
+		},
+		{
+			name: "map invalid data",
+			data: Data{
+				Content: map[string]interface{}{
+					"thing_one": "a thing",
+					"thing_two": "another thing",
+				},
+			},
+			expected: nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tc.expected, tc.data.Map()) {
+				t.Errorf("want: %v, got: %v", tc.expected, tc.data.Map())
+			}
+		})
+	}
+}
+
+func BenchmarkData_MarshalJSON(b *testing.B) {
+	data := Data{
+		Type: "test",
+		Content: map[string]interface{}{
+			"test1": "test1",
+			"test2": "test2",
+			"test3": "test3",
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		data.MarshalJSON()
+	}
+}
+
+func BenchmarkData_MarshalJSON_MissingType(b *testing.B) {
+	data := Data{
+		Content: map[string]interface{}{
+			"test1": "test1",
+			"test2": "test2",
+			"test3": "test3",
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		data.MarshalJSON()
+	}
+}
+
+func BenchmarkData_Map(b *testing.B) {
+	data := Data{
+		Content: map[string]interface{}{
+			"thing_one": "a thing",
+			"thing_two": "another thing",
+		},
+	}
+
+	for i := 0; i < b.N; i++ {
+		data.Map()
+	}
+}
+
+func BenchmarkResponse_ExtractData(b *testing.B) {
+	resp := New(200, StatusOk, "", preparedData)
+	for i := 0; i < b.N; i++ {
+		var dst map[string]interface{}
+		resp.ExtractData("tests", dst)
+	}
+}
+
+// ExampleNew - Example usage for the New function.
+func ExampleNew() {
+	data := &Data{
+		Type: "things",
+		Content: map[string]interface{}{
+			"thing_one": "a thing",
+			"thing_two": "another thing",
+		},
+	}
+
+	resp := New(200, StatusOk, "test message", data)
+	fmt.Printf("%+v", resp)
 }


### PR DESCRIPTION
This PR includes the following:

Refactor of the `response` package:
- Renamed `CreateResponse` to `New()`
- Renamed `MicroserviceResponse` to `Response`
- Added a `Data` struct implementing the json Marshaler interface which replaces the previous Data and Type function arguments which were being passed to CreateResponse.
- Added a bunch of new tests and re-organized the code for the existing ones.
- Added a couple benchmarks
- Made the godoc slightly better :)

Feel free to let me know if anything seems amiss!