### PR TITLE
Simply New method for creating Responses

### DIFF
--- a/format/format_test.go
+++ b/format/format_test.go
@@ -38,7 +38,7 @@ func TestJSONResponseFormatter(t *testing.T) {
 	// Start a HTTP server for testing purposes.
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Create a response.
-		resp := response.New(200, response.StatusOk, "", &responseData)
+		resp := response.New(200, "", &responseData)
 		// Format the response as JSON.
 		JSONResponseFormatter(w, resp)
 	}))

--- a/response/response.go
+++ b/response/response.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net/http"
-
 	"strings"
 
 	"github.com/LUSHDigital/microservice-core-golang/pagination"
@@ -46,7 +45,14 @@ type Response struct {
 //          ...
 //       ]}
 //    }
-func New(code int, status, message string, data *Data) *Response {
+func New(code int, message string, data *Data) *Response {
+	var status string
+	switch {
+	case code >= http.StatusOK && code < http.StatusBadRequest:
+		status = StatusOk
+	default:
+		status = StatusFail
+	}
 	return &Response{
 		Code:    code,
 		Status:  status,

--- a/response/response_test.go
+++ b/response/response_test.go
@@ -42,6 +42,17 @@ var (
 		},
 	}
 
+	// An example response object (wuth data), for a failed response
+	expectedResponseFail = &Response{
+		Status:  StatusFail,
+		Code:    400,
+		Message: "",
+		Data: &Data{
+			Type:    "tests",
+			Content: expectedResponseData,
+		},
+	}
+
 	// An example response object (with no data) for testing with.
 	expectedResponseNoData = &Response{
 		Status:  StatusOk,
@@ -57,7 +68,6 @@ func TestNew(t *testing.T) {
 	tt := []struct {
 		name     string
 		code     int
-		status   string
 		message  string
 		typ      string
 		data     *Data
@@ -66,15 +76,20 @@ func TestNew(t *testing.T) {
 		{
 			name:     "response valid",
 			code:     200,
-			status:   StatusOk,
 			message:  "",
 			data:     preparedData,
 			expected: expectedResponse,
 		},
 		{
+			name:     "response valid",
+			code:     400,
+			message:  "",
+			data:     preparedData,
+			expected: expectedResponseFail,
+		},
+		{
 			name:     "response no data",
 			code:     200,
-			status:   StatusOk,
 			message:  "",
 			data:     nil,
 			expected: expectedResponseNoData,
@@ -83,7 +98,7 @@ func TestNew(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			resp := New(tc.code, tc.status, tc.message, tc.data)
+			resp := New(tc.code, tc.message, tc.data)
 
 			if !reflect.DeepEqual(resp, tc.expected) {
 				t.Errorf("want: %v\ngot: %v", tc.expected, resp)
@@ -93,7 +108,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestResponse_ExtractData(t *testing.T) {
-	resp := New(200, StatusOk, "", preparedData)
+	resp := New(200, "", preparedData)
 	//
 	// Extract the data.
 	var dst map[string]interface{}
@@ -105,7 +120,7 @@ func TestResponse_ExtractData(t *testing.T) {
 	}
 
 	// test with broken data as well
-	resp = New(200, StatusOk, "", &Data{
+	resp = New(200, "", &Data{
 		Content: expectedResponseData,
 	})
 	//
@@ -398,7 +413,7 @@ func BenchmarkData_Map(b *testing.B) {
 func BenchmarkResponse_ExtractData(b *testing.B) {
 	log.SetOutput(ioutil.Discard)
 	defer log.SetOutput(os.Stderr)
-	resp := New(200, StatusOk, "", preparedData)
+	resp := New(200, "", preparedData)
 	for i := 0; i < b.N; i++ {
 		var dst map[string]interface{}
 		resp.ExtractData("tests", dst)
@@ -415,6 +430,6 @@ func ExampleNew() {
 		},
 	}
 
-	resp := New(200, StatusOk, "test message", data)
+	resp := New(200, "test message", data)
 	fmt.Printf("%+v", resp)
 }


### PR DESCRIPTION
This change removes the need to pass in the StatusOk / StatusFail when using `responses.New()`