### PR TITLE
Feature/cockroachdb migrator

### DIFF
--- a/migrate/cockroach.go
+++ b/migrate/cockroach.go
@@ -1,0 +1,175 @@
+package migrate
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"path/filepath"
+
+	_ "github.com/lib/pq"
+
+	"github.com/mattes/migrate"
+	"github.com/mattes/migrate/database/cockroachdb"
+	"strconv"
+	"strings"
+)
+
+type Cockroach struct {
+	db *sql.DB
+
+	MigrationsPath string
+}
+
+type CockroachOptions struct {
+	*ConnectionOptions
+
+	MigrationTable string
+	Secure         bool
+	SSL            *CockroachSSL
+}
+
+type CockroachSSL struct {
+	CertPath, KeyPath, Mode, RootCert string
+}
+
+const (
+	DefaultHost           = "localhost"
+	DefaultUser           = "cockroach"
+	DefaultPort           = "26257"
+	DefaultDatabase       = "service-db"
+	DefaultMigrationTable = "schema_migrations"
+)
+
+// Connection string concatenates the CockroachOptions down to a string,
+// applying defaults to options that were not set ready to be used in a
+// connection to the database
+func (co *CockroachOptions) ConnectionString() (string, error) {
+	var conn strings.Builder
+
+	conn.WriteString("cockroach://")
+
+	// Prevent panics and just return the exact default upon nil options
+	if co.ConnectionOptions == nil {
+		return fmt.Sprintf(
+			"cockroach://%s@%s:%s/%s?sslmode=disable&x-migrations-table=%s",
+			DefaultUser, DefaultHost, DefaultPort, DefaultDatabase, DefaultMigrationTable,
+		), nil
+	}
+
+	// User
+	if len(co.User) != 0 {
+		conn.WriteString(co.User)
+	} else {
+		conn.WriteString(DefaultUser)
+	}
+
+	conn.WriteString("@")
+
+	// Host
+	if len(co.Host) != 0 {
+		conn.WriteString(co.Host)
+	} else {
+		conn.WriteString(DefaultHost)
+	}
+
+	conn.WriteString(":")
+
+	// Port
+	if co.Port != 0 {
+		conn.WriteString(strconv.Itoa(co.Port))
+	} else {
+		conn.WriteString(DefaultPort)
+	}
+
+	conn.WriteString("/")
+
+	if len(co.Database) != 0 {
+		conn.WriteString(co.Database)
+	} else {
+		conn.WriteString(DefaultDatabase)
+	}
+
+	// Set connection security
+	if co.Secure {
+		conn.WriteString(fmt.Sprintf("?sslcert=%s", co.SSL.CertPath))
+		conn.WriteString(fmt.Sprintf("?sslkey=%s", co.SSL.KeyPath))
+		conn.WriteString(fmt.Sprintf("?sslmode=%s", co.SSL.Mode))
+		conn.WriteString(fmt.Sprintf("?sslrootcert=%s", co.SSL.RootCert))
+	} else {
+		conn.WriteString("?sslmode=disable")
+	}
+
+	if len(co.MigrationTable) != 0 {
+		conn.WriteString(fmt.Sprintf("&x-migrations-table=%s",
+			co.MigrationTable))
+	} else {
+		conn.WriteString(fmt.Sprintf("&x-migrations-table=%s"))
+	}
+
+	return conn.String(), nil
+}
+
+func NewCockroach(opts *CockroachOptions) (*Cockroach, error) {
+	conn, err := opts.ConnectionString()
+	if err != nil {
+		return nil, err
+	}
+
+	db, err := sql.Open("postgres", conn)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Cockroach{db: db}, nil
+}
+
+func (c *Cockroach) Migrate() error {
+	driver, err := cockroachdb.WithInstance(c.db, &cockroachdb.Config{})
+	if err != nil {
+		log.Fatalf("could not get migrations driver: %s", err)
+	}
+
+	if !c.migrationsInPath() {
+		return errors.New("migrate: no migration files exist in given path")
+	}
+
+	m, err := migrate.NewWithDatabaseInstance(
+		fmt.Sprintf("file://%s", c.MigrationsPath),
+		"sql",
+		driver,
+	)
+
+	if err != nil {
+		return fmt.Errorf("migrate: could not initialise migrations: %s", err)
+	}
+
+	return m.Up()
+}
+
+// migrationsInPath will assert whether the configured migrations path has
+// migrations ready to be ran.
+func (c *Cockroach) migrationsInPath() bool {
+	// Ensure we have a migration path
+	if len(c.MigrationsPath) == 0 {
+		return false
+	}
+
+	// Pull all files up from the migrations path
+	files, err := ioutil.ReadDir(c.MigrationsPath)
+	if err != nil {
+		return false
+	}
+
+	// If one sql file exists we can consider this a valid migration directory.
+	for _, file := range files {
+		if file.Mode().IsRegular() &&
+			filepath.Ext(file.Name()) == ".sql" {
+			return true
+		}
+	}
+
+	// If no SQL files were found whilst traversing a path - then none exists!
+	return false
+}

--- a/migrate/cockroach.go
+++ b/migrate/cockroach.go
@@ -7,13 +7,14 @@ import (
 	"io/ioutil"
 	"log"
 	"path/filepath"
-
-	_ "github.com/lib/pq"
+	"strconv"
+	"strings"
 
 	"github.com/mattes/migrate"
 	"github.com/mattes/migrate/database/cockroachdb"
-	"strconv"
-	"strings"
+	_ "github.com/mattes/migrate/source/file"
+
+	_ "github.com/lib/pq"
 )
 
 type Cockroach struct {
@@ -36,9 +37,9 @@ type CockroachSSL struct {
 
 const (
 	DefaultHost           = "localhost"
-	DefaultUser           = "cockroach"
+	DefaultUser           = "root"
 	DefaultPort           = "26257"
-	DefaultDatabase       = "service-db"
+	DefaultDatabase       = "service"
 	DefaultMigrationTable = "schema_migrations"
 )
 
@@ -46,18 +47,17 @@ const (
 // applying defaults to options that were not set ready to be used in a
 // connection to the database
 func (co *CockroachOptions) ConnectionString() (string, error) {
-	var conn strings.Builder
-
-	conn.WriteString("cockroach://")
-
 	// Prevent panics and just return the exact default upon nil options
 	if co.ConnectionOptions == nil {
 		return fmt.Sprintf(
-			"cockroach://%s@%s:%s/%s?sslmode=disable&x-migrations-table=%s",
+			"postgresql://%s@%s:%s/%s?sslmode=disable&x-migrations-table=%s",
 			DefaultUser, DefaultHost, DefaultPort, DefaultDatabase, DefaultMigrationTable,
 		), nil
 	}
 
+	// Start a string builder for the connection string
+	var conn strings.Builder
+	conn.WriteString("postgresql://")
 	// User
 	if len(co.User) != 0 {
 		conn.WriteString(co.User)

--- a/migrate/cockroach.go
+++ b/migrate/cockroach.go
@@ -12,8 +12,12 @@ import (
 
 	"github.com/mattes/migrate"
 	"github.com/mattes/migrate/database/cockroachdb"
+	// file is imported for its side-affect of loading migration files from
+	// disk when specifying the migrations directory
 	_ "github.com/mattes/migrate/source/file"
 
+	// pq is imported for its  side-affect of using postgresql:// the sql
+	// connection string
 	_ "github.com/lib/pq"
 )
 

--- a/migrate/cockroach_test.go
+++ b/migrate/cockroach_test.go
@@ -1,0 +1,115 @@
+package migrate
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCockroach_HasMigrationsInPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			"passing",
+			"{CALCULATED}",
+			true,
+		},
+		{
+			"failing - no path",
+			"",
+			false,
+		},
+		{
+			"failing - invalid path",
+			"/etc/ihope/i/dont/exist	",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Cockroach{}
+
+			// Path setup for passing tests
+			if tt.path == "{CALCULATED}" {
+				var (
+					dir  = os.TempDir()
+					file = fmt.Sprintf("%s/temp.sql", dir)
+				)
+				defer os.RemoveAll(dir)
+
+				err := ioutil.WriteFile(file, nil, 0644)
+				assert.Nil(t, err)
+
+				// Update path
+				c.MigrationsPath = dir
+			}
+
+			assert.Equal(t, tt.expected, c.migrationsInPath())
+		})
+	}
+}
+
+func TestCockroachOptions_ConnectionString(t *testing.T) {
+	type fields struct {
+		ConnectionOptions *ConnectionOptions
+		MigrationTable    string
+		Secure            bool
+		SSL               *CockroachSSL
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+		{
+			"Passing - insecure options",
+			fields{
+				&ConnectionOptions{
+					User:     "test-user",
+					Port:     9001,
+					Host:     "test-host",
+					Database: "test-database",
+				},
+				"migration_table",
+				false,
+				nil,
+			},
+			"cockroach://test-user@test-host:9001/test-database?sslmode=disable&x-migrations-table=migration_table",
+			false,
+		},
+		{
+			"Passing - defaults",
+			fields{},
+			"cockroach://cockroach@localhost:26257/service-db?sslmode=disable&x-migrations-table=schema_migrations",
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			co := &CockroachOptions{
+				ConnectionOptions: tt.fields.ConnectionOptions,
+				MigrationTable:    tt.fields.MigrationTable,
+				Secure:            tt.fields.Secure,
+				SSL:               tt.fields.SSL,
+			}
+			got, err := co.ConnectionString()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CockroachOptions.ConnectionString() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CockroachOptions.ConnectionString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/migrate/cockroach_test.go
+++ b/migrate/cockroach_test.go
@@ -68,7 +68,6 @@ func TestCockroachOptions_ConnectionString(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		// TODO: Add test cases.
 		{
 			"Passing - insecure options",
 			fields{
@@ -82,13 +81,14 @@ func TestCockroachOptions_ConnectionString(t *testing.T) {
 				false,
 				nil,
 			},
-			"cockroach://test-user@test-host:9001/test-database?sslmode=disable&x-migrations-table=migration_table",
+			"postgresql://test-user@test-host:9001/test-database?sslmode=disable&x-migrations-table=migration_table",
 			false,
 		},
 		{
 			"Passing - defaults",
 			fields{},
-			"cockroach://cockroach@localhost:26257/service-db?sslmode=disable&x-migrations-table=schema_migrations",
+			"postgresql://root@localhost:26257/service?sslmode" +
+				"=disable&x-migrations-table=schema_migrations",
 			false,
 		},
 	}

--- a/migrate/cockroach_test.go
+++ b/migrate/cockroach_test.go
@@ -35,8 +35,6 @@ func TestCockroach_HasMigrationsInPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Cockroach{}
-
 			// Path setup for passing tests
 			if tt.path == "{CALCULATED}" {
 				var (
@@ -49,10 +47,10 @@ func TestCockroach_HasMigrationsInPath(t *testing.T) {
 				assert.Nil(t, err)
 
 				// Update path
-				c.MigrationsPath = dir
+				tt.path = dir
 			}
 
-			assert.Equal(t, tt.expected, c.migrationsInPath())
+			assert.Equal(t, tt.expected, migrationsInPath(tt.path))
 		})
 	}
 }

--- a/migrate/cockroach_test.go
+++ b/migrate/cockroach_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	_ "github.com/lib/pq"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCockroach_HasMigrationsInPath(t *testing.T) {
@@ -43,14 +42,18 @@ func TestCockroach_HasMigrationsInPath(t *testing.T) {
 				)
 				defer os.RemoveAll(dir)
 
-				err := ioutil.WriteFile(file, nil, 0644)
-				assert.Nil(t, err)
+				if err := ioutil.WriteFile(file, nil, 0644); err != nil {
+					t.Fatal(err)
+				}
 
 				// Update path
 				tt.path = dir
 			}
 
-			assert.Equal(t, tt.expected, migrationsInPath(tt.path))
+			exists := migrationsInPath(tt.path)
+			if tt.expected != exists {
+				t.Errorf("Expected %s but got %d", tt.expected, exists)
+			}
 		})
 	}
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,0 +1,13 @@
+package migrate
+
+type Migrator interface {
+	Migrate() error
+}
+
+type ConnectionOptions struct {
+	Host     string
+	Port     int
+	User     string
+	Pass     string
+	Database string
+}


### PR DESCRIPTION
Adding a wrapper around github.com/mattes/migrate for running database migrations, with some defaults for connections.