### PR TITLE
Package re-naming

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -1,4 +1,4 @@
-package microservicetransport
+package transport
 
 import (
 	"net/http"

--- a/transport/cloudservice.go
+++ b/transport/cloudservice.go
@@ -1,4 +1,4 @@
-package microservicetransport
+package transport
 
 import (
 	"bytes"

--- a/transport/cloudservice_test.go
+++ b/transport/cloudservice_test.go
@@ -1,4 +1,4 @@
-package microservicetransport
+package transport
 
 import (
 	"bytes"

--- a/transport/request.go
+++ b/transport/request.go
@@ -1,4 +1,4 @@
-package microservicetransport
+package transport
 
 import (
 	"io"

--- a/transport/service.go
+++ b/transport/service.go
@@ -1,4 +1,4 @@
-package microservicetransport
+package transport
 
 import (
 	"fmt"

--- a/transport/service_test.go
+++ b/transport/service_test.go
@@ -1,4 +1,4 @@
-package microservicetransport
+package transport
 
 import (
 	"bytes"

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,4 +1,4 @@
-package microservicetransport
+package transport
 
 import "net/http"
 


### PR DESCRIPTION
renaming the package `microservicetransport` -> `transport`, as there's no need to prefix this package as it's now a sub-package, as of #17.