### PR TITLE
Added transport agnostic DNS path resolution

### DIFF
--- a/transport/cloudservice.go
+++ b/transport/cloudservice.go
@@ -34,11 +34,13 @@ type CloudService struct {
 func NewCloudService(client *http.Client, branch, env, namespace, name string, credentials *AuthCredentials) *CloudService {
 	return &CloudService{
 		Service: Service{
-			Branch:      branch,
-			Environment: env,
-			Namespace:   namespace,
-			Name:        name,
-			Client:      client,
+			Resource: Resource{
+				Branch:      branch,
+				Environment: env,
+				Namespace:   namespace,
+				Name:        name,
+			},
+			Client: client,
 		},
 		Client:      client,
 		Credentials: credentials,
@@ -47,7 +49,7 @@ func NewCloudService(client *http.Client, branch, env, namespace, name string, c
 
 // authenticate - Authenticate against the API gateway and return an auth token.
 func (c *CloudService) authenticate(request *Request) (*models.Token, error) {
-	//loginBody := new(bytes.Buffer)
+	// loginBody := new(bytes.Buffer)
 	loginBody, err := json.Marshal(c.Credentials)
 	if err != nil {
 		return nil, fmt.Errorf("cannot encode json: %s", err)

--- a/transport/cloudservice_test.go
+++ b/transport/cloudservice_test.go
@@ -49,11 +49,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "GET HTTP",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -72,11 +74,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "GET HTTPS",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -95,11 +99,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "GET with query HTTP",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -122,11 +128,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "GET with query HTTPS",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -149,11 +157,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "POST HTTP",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -176,11 +186,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "POST HTTPS",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -203,11 +215,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "POST with query HTTP",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -234,11 +248,13 @@ func TestCloudService_Dial(t *testing.T) {
 			name: "POST with query HTTPS",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
-					Client:      DefaultHTTPClient(),
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
+					Client: DefaultHTTPClient(),
 				},
 				Client: DefaultHTTPClient(),
 				Credentials: &AuthCredentials{
@@ -300,10 +316,12 @@ func TestCloudService_GetName(t *testing.T) {
 			name: "Normal",
 			service: CloudService{
 				Service: Service{
-					Branch:      "master",
-					Environment: "staging",
-					Namespace:   "services",
-					Name:        "myservice",
+					Resource: Resource{
+						Branch:      "master",
+						Environment: "staging",
+						Namespace:   "services",
+						Name:        "myservice",
+					},
 				},
 				Credentials: &AuthCredentials{
 					Email:    "test@test.com",
@@ -316,10 +334,12 @@ func TestCloudService_GetName(t *testing.T) {
 			name: "Crazy",
 			service: CloudService{
 				Service: Service{
-					Branch:      "massdsdfsdjf89uter",
-					Environment: "sdfsdf34341",
-					Namespace:   "l1j2312klj3k21j3",
-					Name:        "-sf9s9f9ds0f9-",
+					Resource: Resource{
+						Branch:      "massdsdfsdjf89uter",
+						Environment: "sdfsdf34341",
+						Namespace:   "l1j2312klj3k21j3",
+						Name:        "-sf9s9f9ds0f9-",
+					},
 				},
 				Credentials: &AuthCredentials{
 					Email:    "test@test.com",
@@ -370,10 +390,12 @@ func TestCloudService_GetApiGatewayUrl(t *testing.T) {
 	// Instantiate the service.
 	myService := &CloudService{
 		Service: Service{
-			Branch:      "master",
-			Environment: "staging",
-			Namespace:   "services",
-			Name:        "myservice",
+			Resource: Resource{
+				Branch:      "master",
+				Environment: "staging",
+				Namespace:   "services",
+				Name:        "myservice",
+			},
 		},
 		Credentials: &AuthCredentials{
 			Email:    "test@test.com",

--- a/transport/service.go
+++ b/transport/service.go
@@ -9,25 +9,49 @@ import (
 	"github.com/LUSHDigital/microservice-core-golang/transport/domain"
 )
 
-// Service - Responsible for communication with a service.
-type Service struct {
+// Resource - Useful for defining a remote resource without an attached transport.
+type Resource struct {
 	Branch         string        // VCS branch the service is built from.
 	CurrentRequest *http.Request // Current HTTP request being actioned.
 	Environment    string        // CI environment the service operates in.
 	Namespace      string        // Namespace of the service.
 	Name           string        // Name of the service.
 	Version        int           // Major API version of the service.
-	Client         *http.Client  // http client implementation
+}
+
+// DNSPath returns internal dns path for the resource
+func (r *Resource) DNSPath() string {
+	// Make any alterations based upon the namespace.
+	switch r.Namespace {
+	case "aggregators":
+		if !strings.HasPrefix(r.Name, config.AggregatorDomainPrefix) {
+			r.Name = strings.Join([]string{config.AggregatorDomainPrefix, r.Name}, "-")
+		}
+	}
+	// Determine the service namespace to use based on the service version.
+	serviceNamespace := r.Name
+	if r.Version != 0 {
+		serviceNamespace = fmt.Sprintf("%r-%d", serviceNamespace, r.Version)
+	}
+	return serviceNamespace
+}
+
+// Service - Responsible for communication with a service.
+type Service struct {
+	Resource
+	Client *http.Client // http client implementation
 }
 
 // NewService - prepares a new service with the provided parameters and client.
 func NewService(client *http.Client, branch, env, namespace, name string) *Service {
 	return &Service{
-		Branch:      branch,
-		Name:        name,
-		Environment: env,
-		Namespace:   namespace,
-		Client:      client,
+		Resource: Resource{
+			Branch:      branch,
+			Name:        name,
+			Environment: env,
+			Namespace:   namespace,
+		},
+		Client: client,
 	}
 }
 
@@ -40,20 +64,7 @@ func (s *Service) Call() (*http.Response, error) {
 func (s *Service) Dial(request *Request) error {
 	var err error
 
-	// Make any alterations based upon the namespace.
-	switch s.Namespace {
-	case "aggregators":
-		if !strings.HasPrefix(s.Name, config.AggregatorDomainPrefix) {
-			s.Name = strings.Join([]string{config.AggregatorDomainPrefix, s.Name}, "-")
-		}
-	}
-
-	// Determine the service namespace to use based on the service version.
-	serviceNamespace := s.Name
-	if s.Version != 0 {
-		serviceNamespace = fmt.Sprintf("%s-%d", serviceNamespace, s.Version)
-	}
-
+	serviceNamespace := s.DNSPath()
 	// Get the name of the service.
 	dnsName := domain.BuildServiceDNSName(s.Name, s.Branch, s.Environment, serviceNamespace)
 

--- a/transport/service.go
+++ b/transport/service.go
@@ -31,7 +31,7 @@ func (r *Resource) DNSPath() string {
 	// Determine the service namespace to use based on the service version.
 	serviceNamespace := r.Name
 	if r.Version != 0 {
-		serviceNamespace = fmt.Sprintf("%r-%d", serviceNamespace, r.Version)
+		serviceNamespace = fmt.Sprintf("%s-%d", serviceNamespace, r.Version)
 	}
 	return serviceNamespace
 }

--- a/transport/service_test.go
+++ b/transport/service_test.go
@@ -9,8 +9,9 @@ import (
 	"net/url"
 	"testing"
 	"time"
-	"github.com/LUSHDigital/microservice-core-golang/transport/config"
+
 	"github.com/LUSHDigital/microservice-core-golang/response"
+	"github.com/LUSHDigital/microservice-core-golang/transport/config"
 )
 
 func TestService_Dial(t *testing.T) {
@@ -25,10 +26,12 @@ func TestService_Dial(t *testing.T) {
 
 			name: "name has agg- prefix",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "agg-myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "agg-myservice",
+				},
 			},
 			request: &Request{
 				Method:   http.MethodGet,
@@ -40,10 +43,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "GET HTTP",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			request: &Request{
 				Method:   http.MethodGet,
@@ -55,10 +60,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "GET HTTPS",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			request: &Request{
 				Method:   http.MethodGet,
@@ -70,10 +77,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "GET with query HTTP",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			request: &Request{
 				Method:   http.MethodGet,
@@ -89,10 +98,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "GET with query HTTPS",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			request: &Request{
 				Method:   http.MethodGet,
@@ -108,10 +119,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "POST HTTP",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			postData: map[string]string{
 				"foo": "bar",
@@ -127,10 +140,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "POST HTTPS",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			postData: map[string]string{
 				"foo": "bar",
@@ -146,10 +161,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "POST with query HTTP",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			postData: map[string]string{
 				"foo": "bar",
@@ -169,10 +186,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "POST with query HTTPS",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			postData: map[string]string{
 				"foo": "bar",
@@ -192,10 +211,12 @@ func TestService_Dial(t *testing.T) {
 		{
 			name: "POST with headers",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			postData: map[string]string{
 				"foo": "bar",
@@ -255,20 +276,24 @@ func TestService_GetName(t *testing.T) {
 		{
 			name: "Normal",
 			service: Service{
-				Branch:      "master",
-				Environment: "staging",
-				Namespace:   "services",
-				Name:        "myservice",
+				Resource: Resource{
+					Branch:      "master",
+					Environment: "staging",
+					Namespace:   "services",
+					Name:        "myservice",
+				},
 			},
 			expectedName: "myservice",
 		},
 		{
 			name: "Crazy",
 			service: Service{
-				Branch:      "massdsdfsdjf89uter",
-				Environment: "sdfsdf34341",
-				Namespace:   "l1j2312klj3k21j3",
-				Name:        "-sf9s9f9ds0f9-",
+				Resource: Resource{
+					Branch:      "massdsdfsdjf89uter",
+					Environment: "sdfsdf34341",
+					Namespace:   "l1j2312klj3k21j3",
+					Name:        "-sf9s9f9ds0f9-",
+				},
 			},
 			expectedName: "-sf9s9f9ds0f9-",
 		},


### PR DESCRIPTION
This makes it so a `Resource` can be configured and used to build a valid DNS path regardless of transport.

This implicitely allows us to reuse transport for GRPC.