### PR TITLE
Split out JWT validation to its own function to be invoked individually

### DIFF
--- a/auth/jwt.go
+++ b/auth/jwt.go
@@ -26,51 +26,71 @@ type JWTClaims struct {
 	jwt.StandardClaims
 }
 
+// JWTResponder defines the behaviour of validating a JWT
+type JWTResponder interface {
+	OnUnauthorizedErr(err error)
+	OnComplete(token *jwt.Token)
+}
+
+type jwtHTTPResponder struct {
+	w    http.ResponseWriter
+	r    *http.Request
+	next http.HandlerFunc
+}
+
+func (r *jwtHTTPResponder) OnUnauthorizedErr(err error) {
+	response.New(http.StatusUnauthorized, err.Error(), nil).WriteTo(r.w)
+}
+
+func (r *jwtHTTPResponder) OnComplete(token *jwt.Token) {
+	ctx := ContextWithConsumer(r.r.Context(), token.Claims.(*JWTClaims).Consumer)
+	r.next.ServeHTTP(r.w, r.r.WithContext(ctx))
+}
+
+// ValidateJWT takes the raw JWT and the public RSA key
+func ValidateJWT(raw string, publicKey *rsa.PublicKey, responder JWTResponder) {
+	// Parse the JWT token
+	token, err := jwt.ParseWithClaims(raw, &JWTClaims{}, func(t *jwt.Token) (interface{}, error) {
+		// Ensure the signing method was not changed
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
+		}
+		return publicKey, nil
+	})
+
+	// Bail out if the token could not be parsed
+	if err != nil {
+		if _, ok := err.(*jwt.ValidationError); ok {
+			// Handle any token specific errors
+			var errorMessage string
+			if err.(*jwt.ValidationError).Errors&jwt.ValidationErrorMalformed != 0 {
+				errorMessage = errorMessageMalformed
+			} else if err.(*jwt.ValidationError).Errors&(jwt.ValidationErrorExpired|jwt.ValidationErrorNotValidYet) != 0 {
+				errorMessage = errorMessageExpired
+			} else {
+				errorMessage = errorMessageInvalid
+			}
+			responder.OnUnauthorizedErr(fmt.Errorf(errorMessage))
+			return
+		}
+		responder.OnUnauthorizedErr(fmt.Errorf(errorMessageInvalid))
+		return
+	}
+
+	// Check the claims and token are valid
+	if _, ok := token.Claims.(*JWTClaims); !ok || !token.Valid {
+		responder.OnUnauthorizedErr(fmt.Errorf(errorMessageClaimsInvalid))
+		return
+	}
+
+	responder.OnComplete(token)
+}
+
 // HandlerValidateJWT takes a JWT from the request headers, attempts validation and returns a http handler.
 func HandlerValidateJWT(publicKey *rsa.PublicKey, next http.HandlerFunc) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := strings.TrimPrefix(r.Header.Get(authHeader), authHeaderPrefix)
-
-		// Parse the JWT token.
-		authToken, err := jwt.ParseWithClaims(token, &JWTClaims{}, func(aToken *jwt.Token) (interface{}, error) {
-			// Ensure the signing method was not changed.
-			if _, ok := aToken.Method.(*jwt.SigningMethodRSA); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v", aToken.Header["alg"])
-			}
-
-			return publicKey, nil
-		})
-
-		// Bail out if the token could not be parsed.
-		if err != nil {
-			if _, ok := err.(*jwt.ValidationError); ok {
-				// Handle any token specific errors.
-				var errorMessage string
-
-				if err.(*jwt.ValidationError).Errors&jwt.ValidationErrorMalformed != 0 {
-					errorMessage = errorMessageMalformed
-				} else if err.(*jwt.ValidationError).Errors&(jwt.ValidationErrorExpired|jwt.ValidationErrorNotValidYet) != 0 {
-					errorMessage = errorMessageExpired
-				} else {
-					errorMessage = errorMessageInvalid
-				}
-
-				response.New(http.StatusUnauthorized, errorMessage, nil).WriteTo(w)
-				return
-			}
-
-			response.New(http.StatusUnauthorized, errorMessageInvalid, nil).WriteTo(w)
-		}
-
-		// Check the claims and token are valid.
-		if _, ok := authToken.Claims.(*JWTClaims); !ok || !authToken.Valid {
-			response.New(http.StatusUnauthorized, errorMessageClaimsInvalid, nil).WriteTo(w)
-			return
-		}
-
-		// Add the customer ID to the request context.
-		ctx := ContextWithConsumer(r.Context(), authToken.Claims.(*JWTClaims).Consumer)
-
-		next.ServeHTTP(w, r.WithContext(ctx))
+		responder := &jwtHTTPResponder{w, r, next}
+		ValidateJWT(token, publicKey, responder)
 	})
 }


### PR DESCRIPTION
We do this so we can validate JWT outside the context of HTTP, eg. gRPC services.